### PR TITLE
nit global vars

### DIFF
--- a/entry/endpoints.cc
+++ b/entry/endpoints.cc
@@ -15,17 +15,12 @@ using std::string;
 using std::cerr;
 using std::endl;
 
-std::unique_ptr<BaseData> data;
-std::unique_ptr<BaseMatcher> matcher;
+std::unique_ptr<BaseData> Endpoints::data = std::make_unique<Data>();
+std::unique_ptr<BaseMatcher> Endpoints::matcher = std::make_unique<Matcher>();
 
-void set_mode_prod() {
-    data = std::make_unique<Data>();
-    matcher = std::make_unique<Matcher>();
-}
-
-void set_mode_mock(MockData& data, MockMatcher& matcher) {
-    ::data.reset(&data);
-    ::matcher.reset(&matcher);
+void Endpoints::set_mode_test(MockData& mock_data, MockMatcher& mock_matcher) {
+    Endpoints::data.reset(&mock_data);
+    Endpoints::matcher.reset(&mock_matcher);
 }
 
 static string gen_random_str(const int len) {

--- a/entry/endpoints.h
+++ b/entry/endpoints.h
@@ -15,14 +15,14 @@
 #include "engine/mock_matcher.h"
 #include "crow.h"
 
-extern std::unique_ptr<BaseData> data;
-extern std::unique_ptr<BaseMatcher> matcher;
-
-void set_mode_prod();
-void set_mode_mock(MockData& data, MockMatcher& matcher);
-
 class Endpoints {
+
+    static std::unique_ptr<BaseData> data;
+    static std::unique_ptr<BaseMatcher> matcher;
+
 public:
+    // default to production mode: actual backing not mocks
+    static void set_mode_test(MockData& mock_data, MockMatcher& mock_matcher);
 
     static crow::response validate_credentials(const crow::request& req);
     static crow::response generate_credentials(const crow::request& req);

--- a/entry/endpoints_test.cc
+++ b/entry/endpoints_test.cc
@@ -19,7 +19,7 @@ protected:
     MockMatcher matcher;
 
     void SetUp() override {
-        set_mode_mock(data, matcher);
+        Endpoints::set_mode_test(data, matcher);
 
         AuthenticUser nick{ "nick", "nick_key" };
 


### PR DESCRIPTION
using global vars is probably bad, this makes the Base unique ptrs used by endpoints static member variables instead of globals